### PR TITLE
Update TimeTool.cs

### DIFF
--- a/TimePeriod/TimeTool.cs
+++ b/TimePeriod/TimeTool.cs
@@ -349,7 +349,9 @@ namespace Itenso.TimePeriod
 			int currentYear;
 			int currentWeek;
 			GetWeekOfYear( dateTime, culture, weekRule, firstDayOfWeek, yearWeekType, out currentYear, out currentWeek );
-
+			
+			// get last week day of the week
+			DayOfWeek lastDayOfWeek = (DayOfWeek)(((int)firstDayOfWeek + TimeSpec.DaysPerWeek - 1) % TimeSpec.DaysPerWeek);
 
 			// end date of week
 			while ( currentWeek != weekOfYear )
@@ -358,8 +360,8 @@ namespace Itenso.TimePeriod
 				GetWeekOfYear( dateTime, culture, weekRule, firstDayOfWeek, yearWeekType, out currentYear, out currentWeek );
 			}
 
-			// end of previous week
-			while ( currentWeek == weekOfYear )
+			// end of previous week => keep on going until got last week day
+			while (currentWeek == weekOfYear || dateTime.DayOfWeek != lastDayOfWeek)
 			{
 				dateTime = dateTime.AddDays( -1 );
 				GetWeekOfYear( dateTime, culture, weekRule, firstDayOfWeek, yearWeekType, out currentYear, out currentWeek );


### PR DESCRIPTION
Error creating a week instance at the beginning of the year, the start and end dates are wrong. Ex
DateTime moment = new DateTime (2019, 1, 2);
Console.WriteLine ("Date {0}:", moment.ToShortDateString ());
var w = new Week (moment);
Console.WriteLine ("Week: {0} {1} - {2}", w, w.FirstDayOfWeek.DayOfWeek, w.LastDayOfWeek.DayOfWeek);
// got: w / c 1 2019; 2019-01-01 - 2019-01-07 | 6.23: 59 Tuesday-Monday
// expecting: Week: w / c 1 2019; 2019-01-01 - 2019-01-05 Sunday-Saturday