### PR TITLE
Bugfix for TimePeriodSubtractor - parameter "combinePeriods"

### DIFF
--- a/TimePeriod/TimePeriodSubtractor.cs
+++ b/TimePeriod/TimePeriodSubtractor.cs
@@ -59,10 +59,13 @@ namespace Itenso.TimePeriod
 				return new TimePeriodCollection( sourcePeriods );
 			}
 
-			// combined source periods
-			sourcePeriods = timePeriodCombiner.CombinePeriods( sourcePeriods );
+            if (combinePeriods)
+            {
+                // combined source periods
+                sourcePeriods = timePeriodCombiner.CombinePeriods(sourcePeriods);
+            }
 
-			// combined subtracting periods
+            // combined subtracting periods
 			if ( subtractingPeriods.Count == 0 )
 			{
 				return new TimePeriodCollection( sourcePeriods );

--- a/TimePeriodTests/TimePeriodSubtractorTest.cs
+++ b/TimePeriodTests/TimePeriodSubtractorTest.cs
@@ -154,6 +154,19 @@ namespace Itenso.TimePeriodTests
             Assert.Equal(1, periods.Count);
         } // NoSubtractionNotCombineTest
 
+        // ----------------------------------------------------------------------
+        [Trait("Category", "TimePeriodSubtractor")]
+        [Fact]
+        public void SubtractionNotCombineTest2()
+        {
+            TimeRange sourcePeriod = new TimeRange(new DateTime(2011, 3, 01), new DateTime(2011, 3, 10));
+            TimeRange subtractPeriod = new TimeRange(new DateTime(2011, 3, 05), new DateTime(2011, 3, 06));
+            TimePeriodSubtractor<TimeRange> periodSubtractor = new TimePeriodSubtractor<TimeRange>();
+            ITimePeriodCollection periods = periodSubtractor.SubtractPeriods(
+                new TimePeriodCollection { sourcePeriod }, new TimePeriodCollection { subtractPeriod }, false);
+            Assert.Equal(2, periods.Count);
+        } // NoSubtractionNotCombineTest
+
     } // class TimePeriodSubtractorTest
 
 } // namespace Itenso.TimePeriodTests

--- a/TimePeriodTests/TimePeriodSubtractorTest.cs
+++ b/TimePeriodTests/TimePeriodSubtractorTest.cs
@@ -159,12 +159,13 @@ namespace Itenso.TimePeriodTests
         [Fact]
         public void SubtractionNotCombineTest2()
         {
-            TimeRange sourcePeriod = new TimeRange(new DateTime(2011, 3, 01), new DateTime(2011, 3, 10));
+            TimeRange sourcePeriod1 = new TimeRange(new DateTime(2011, 3, 01), new DateTime(2011, 3, 04));
+            TimeRange sourcePeriod2 = new TimeRange(new DateTime(2011, 3, 04), new DateTime(2011, 3, 10));
             TimeRange subtractPeriod = new TimeRange(new DateTime(2011, 3, 05), new DateTime(2011, 3, 06));
             TimePeriodSubtractor<TimeRange> periodSubtractor = new TimePeriodSubtractor<TimeRange>();
             ITimePeriodCollection periods = periodSubtractor.SubtractPeriods(
-                new TimePeriodCollection { sourcePeriod }, new TimePeriodCollection { subtractPeriod }, false);
-            Assert.Equal(2, periods.Count);
+                new TimePeriodCollection { sourcePeriod1, sourcePeriod2 }, new TimePeriodCollection { subtractPeriod }, false);
+            Assert.Equal(3, periods.Count);
         } // NoSubtractionNotCombineTest
 
     } // class TimePeriodSubtractorTest


### PR DESCRIPTION
Bugfix for TimePeriodSubtractor - parameter "combinePeriods"


```
source  ---|------   
remove        --
result  ---|--  --
```
source has 2 segments that touch each other

result has now 3 segments - first source segment is untouched, 2nd source segment got split into two pieces